### PR TITLE
Generate JAR for headless example

### DIFF
--- a/src/main/java/com/chartiq/finsemble/example/JavaExample.java
+++ b/src/main/java/com/chartiq/finsemble/example/JavaExample.java
@@ -123,7 +123,7 @@ public class JavaExample {
                     LOGGER.log(Level.SEVERE, "Error from Finsemble", e);
                 }
             });
-            fsbl.register();
+
             appendMessage("Window registered with Finsemble");
 
             // populate component combo box

--- a/src/main/java/com/chartiq/finsemble/example/JavaSwingExample.java
+++ b/src/main/java/com/chartiq/finsemble/example/JavaSwingExample.java
@@ -244,7 +244,7 @@ public class JavaSwingExample extends JFrame implements WindowListener {
                     LOGGER.log(Level.SEVERE, "Error from Finsemble", e);
                 }
             });
-            fsbl.register();
+
             appendMessage("Window registered with Finsemble");
 
             initForm();


### PR DESCRIPTION
chore: #id [18972]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18972/details)

**Description of change**
* Build JAR for JavaFX and Headless example
* Use that in java-example.json
* Remove accidentally added swing config

**Description of testing**
1. Setup seed as described in the README
1. `mvn package` the finsemble-java-example project
1. Open Central Logger
    1. [x] Should see messages from the headless example
1. Launch JavaFX example
    1. [x] JavaFX example should launch and connect to Finsemble
1. Launch component from JavaFX example
    1. [x] Component should launch